### PR TITLE
Add --skip 10 for fswebcam

### DIFF
--- a/snap_handlers.js
+++ b/snap_handlers.js
@@ -15,6 +15,8 @@ module.exports = {
     '-D',
     3.0,
     '--no-banner',
+    '--skip',
+    10,
     filename,
   ]);
  },


### PR DESCRIPTION
10 "warm up" shots/frames? prior to taking the actual picture.  Results in better quality for `fswebcam` on the Raspberry Pi.